### PR TITLE
Add mock for T.bind

### DIFF
--- a/lib/sorbet-runtime-stub.rb
+++ b/lib/sorbet-runtime-stub.rb
@@ -21,6 +21,9 @@ module T
     def type_parameter(name); end
     def untyped; end
 
+    # https://sorbet.org/docs/type-assertions#tbind
+    def bind(_self, klass); end
+
     def assert_type!(value, _type, _checked: true)
       value
     end


### PR DESCRIPTION
Making our own fork of `sorbet-runtime-stub` and adding support for [`T.bind`](https://sorbet.org/docs/type-assertions#tbind)